### PR TITLE
Remove spaces from ruleId and make lowercase

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function attacher(processor, options) {
                 end: match[match.length - 1].position.end
             });
 
-            message.ruleId = phrase;
+            message.ruleId = phrase.replace(/\s+/g, '-').toLowerCase();
             message.source = 'retext-simplify';
         });
     }


### PR DESCRIPTION
Allows ignoring messages with `remark-message-control` when the phrase has spaces.

Right now, if I want to ignore specific simplify messages with `remark-message-control`, for example with something like;
```
<!--quality-docs disable filler overall in addition -->
```
It fails for phrases that contain spaces. This change converts any `ruleId` with spaces into dashes, and makes the string lowercase for consistency. Now I can do this to ignore a rule;
```
<!--quality-docs disable filler overall in-addition -->
```